### PR TITLE
Fix countdown loop: Count from 100 to 0 instead of 0 to 42

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,3 +1,3 @@
-for (let i = 0; i < 42; i++) {
+for (let i = 100; i >= 0; i--) {
     console.log(i);
 }


### PR DESCRIPTION
## Description
This PR fixes the countdown loop bug reported in issue #12.

## Changes Made
- Modified the for loop in `app.js` to count down from 100 to 0 instead of counting up from 0 to 42
- Changed loop initialization from `i = 0` to `i = 100`
- Changed loop condition from `i < 42` to `i >= 0`
- Changed increment from `i++` to `i--`

## Testing
The loop now correctly outputs numbers from 100 down to 0 (inclusive).

## Fixes
Closes #12